### PR TITLE
Feature/better virtualization support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ COPY package*.json ./
 
 RUN npm install
 
+RUN apt update && apt install podman -y
+
 COPY . .
 RUN node_modules/typescript/bin/tsc
 RUN npm install -g .
+
+ENTRYPOINT ["sqc"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2023, Ecogy Energy, Thomas Passmore'
 author = 'Ecogy Energy, Thomas Passmore'
 
 # The full version, including alpha/beta/rc tags
-release = '0.9'
+release = '0.10'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -19,17 +19,36 @@ Firstly, install Docker [#]_. Once this has been accomplished, you can pull the 
     $ docker pull ecogyenergy/solarquant:latest
     $ docker run --rm -it --entrypoint bash ecogyenergy/solarquant:latest
     # sqc -h
-    Usage: sqc [options] [command]
+      Usage: sqc [options] [command]
 
-    Options:
-      -h, --help        display help for command
+      Options:
+        --config <configPath>  Path to config file
+        -h, --help             display help for command
 
-    Commands:
-      config            Manage authenticated sessions
-      projects          Fetch project metadata
-      events            Fetch events
-      datums [options]  Fetch datums from SolarNetwork
-      help [command]    display help for command
+      Commands:
+        config                 Manage authenticated sessions
+        projects               Fetch project metadata
+        events                 Fetch events
+        datums                 Fetch datums from SolarNetwork
+        plugin                 Plugin tools
+        help [command]         display help for command
+
+The recommended way of using SolarQuant is to use a shell alias on Unix-like shells:
+
+.. code-block:: console
+
+    $ docker pull ecogyenergy/solarquant:latest
+    $ docker run --rm -it --entrypoint bash ecogyenergy/solarquant:latest
+    $ alias sqc="docker run --privileged -it --rm -v '$PWD:/local' ecogyenergy/solarquant:latest --config /local/sqc.json"
+    $ sqc -h
+      Usage: sqc [options] [command]
+    ...
+
+.. warning::
+
+    When using the alias, your current working directory should be prepended by `/local/` in your commands. This is
+    because the previous commands mounts your working directory as a volume inside of the SolarQuant environment at
+    this directory.
 
 Installing directly on development machine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,6 +84,7 @@ To use the `sqc` command, add this to your `PATH` environment variable:
       projects          Fetch project metadata
       events            Fetch events
       datums [options]  Fetch datums from SolarNetwork
+      plugin                 Plugin tools
       help [command]    display help for command
 
 .. note::
@@ -255,7 +275,7 @@ Now, let's download all of the datums for an entire month. To flex our muscles a
 
 .. code-block:: console
 
-    $ sqc datums stream /MA/**/INV/* timestamp,watts,current,voltage 2022-05-01 2022-06-01 > datums.csv
+    $ sqc datums stream -s /MA/**/INV/* -f timestamp,watts,current,voltage --start 2022-05-01 --end 2022-06-01 -o datums.csv
     $ head datums.csv
     sourceId,objectId,timestamp,watts,current,voltage
     /MA/PA/S1/INV/12,409,1651363240003,0,0,277.86667
@@ -268,7 +288,7 @@ Now, let's download all of the datums for an entire month. To flex our muscles a
     /MA/PA/S1/INV/12,409,1651363660308,0,0,278.33334
     /MA/PA/S1/INV/12,409,1651363720003,0,0,278.33334
 
-The second argument passed to the stream subcommand is called the format parameter, and it corresponds to the goal
+The `-f` argument passed to the stream subcommand is called the format parameter, and it corresponds to the goal
 CSV header. In this case, we wanted to download the `watts`, `current`, and `voltage` measurements alongside the UNIX
 timestamp of when these measurements were recorded.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solarquant",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "",
   "main": "index.js",
   "type": "module",
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.0",
+    "@types/tmp": "^0.2.3",
     "bats": "^1.8.2",
     "typescript": "^4.8.4"
   },
@@ -33,6 +34,7 @@
     "readline-sync": "^1.4.10",
     "solarnetwork-api-core": "^1.0.0",
     "solarnetwork-datum-loader": "^0.10.6",
+    "tmp": "^0.2.1",
     "true-myth": "^6.2.0",
     "url": "^0.11.0"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,12 @@ import {question} from "readline-sync";
 import {Amplify, Auth} from "aws-amplify";
 import {readFileSync, writeFileSync} from "fs";
 
+export let configPath = "./sqc.json"
+
+export function setConfigPath(v: string) {
+    configPath = v
+}
+
 export interface AMSConfig {
     url?: string,
     region?: string,
@@ -31,7 +37,7 @@ export interface ConfigFile {
 
 export function readConfigFile(): ConfigFile {
     try {
-        const content = readFileSync("./sqc.json").toString()
+        const content = readFileSync(configPath).toString()
         return JSON.parse(content)
     } catch (_e) {
         return {}
@@ -40,7 +46,7 @@ export function readConfigFile(): ConfigFile {
 
 export function writeConfigFile(cfg: ConfigFile) {
     const buf = JSON.stringify(cfg, null, 4)
-    writeFileSync("./sqc.json", buf)
+    writeFileSync(configPath, buf)
 }
 
 export async function authenticateAMS(): Promise<void> {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,118 @@
+import * as child_process from "child_process";
+import {fileSync} from "tmp";
+import {appendFileSync} from "fs";
+
+const spec = `
+openapi: 3.0.0
+info:
+  description: SolarQuant Predictor
+  version: "1.0.0"
+  title: SolarQuant Predictor
+  contact:
+    email: thomas@ecogyenergy.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: predict
+    description: Interact with predictions
+  - name: measure
+    description: Handle incoming measurements
+paths:
+  /predict:
+    post:
+      tags:
+        - predict
+      summary: Gets new prediction
+      operationId: getPredictions
+      description: |
+        By passing in timestamp ranges, obtain a set of predictions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                timestamps:
+                  type: array
+                  items:
+                    type: number
+                  
+            
+      responses:
+        '200':
+          description: Datum predictions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Datum'
+        '400':
+          description: bad input
+          
+  /measure:
+    post:
+      tags:
+        - measure
+      summary: Notifies new measurement
+      operationId: postMeasurements
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                datums:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Datum'
+                  
+            
+      responses:
+        '200':
+          description: Datum predictions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Datum'
+        '400':
+          description: bad input
+
+components:
+  schemas:
+    Datum:
+      type: object
+      required:
+        - timestamp
+      properties:
+        timestamp:
+          type: number
+        i:
+          type: object
+          example:
+            watts: 400
+            voltage: 12.6
+        a:
+          type: object
+          example:
+            wattHours: 8
+        s:
+          type: object
+          example:
+            phase: true
+`
+
+export async function initPlugin(outputDir: string, generator: string, tool: string): Promise<void> {
+    const tmpf = fileSync()
+    appendFileSync(tmpf.name, new Buffer(spec))
+
+    const cmd = `/usr/bin/${tool} run --rm -v "/:/local" --cgroup-manager=cgroupfs --events-backend=file docker.io/openapitools/openapi-generator-cli generate \
+		-i /local${tmpf.name} \
+		-g ${generator} \
+		-o /local${outputDir}`
+
+    child_process.execSync(cmd)
+}

--- a/test/streams.bats
+++ b/test/streams.bats
@@ -7,7 +7,8 @@
 sourceId,objectId,timestamp,voltage
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 timestamp,voltage 2022-12-01 2023-01-01 -a Day)
+  node ../src/ datums stream -s pyr1 -f timestamp,voltage --start 2022-12-01 --end 2023-01-01 -a Day -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -22,7 +23,8 @@ pyr1,1,1670043600000,14.893976233333333,
 pyr1,1,1670130000000,102.06783405555555,
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 timestamp,irradiance,voltage 2022-12-01 2023-01-01 -a Day --partial)
+  node ../src/ datums stream -s pyr1 -f timestamp,irradiance,voltage --start 2022-12-01 --end 2023-01-01 -a Day --partial -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -37,7 +39,8 @@ pyr1,1,1670043600000,
 pyr1,1,1670130000000,
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 timestamp,voltage 2022-12-01 2023-01-01 -a Day --empty)
+  node ../src/ datums stream -s pyr1 -f timestamp,voltage --start 2022-12-01 --end 2023-01-01 -a Day --empty -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -52,7 +55,9 @@ pyr1,1,1670043600000,14.893976233333333,0,117.217224,1440
 pyr1,1,1670130000000,102.06783405555555,0,577.0264,1440
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 timestamp,irradiance\$average,irradiance\$minimum,irradiance\$maximum,irradiance\$count 2022-12-01 2023-01-01 -a Day --empty)
+  node ../src/ datums stream -s pyr1 -f timestamp,irradiance\$average,irradiance\$minimum,irradiance\$maximum,irradiance\$count \
+    --start 2022-12-01 --end 2023-01-01 -a Day --empty -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -66,7 +71,8 @@ pyr1,1,1670043600000,14.893976233333333
 pyr1,1,1670130000000,102.06783405555555
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 timestamp,irradiance 2022-12-01 2023-01-01 -a Day --empty)
+  node ../src/ datums stream -s pyr1 -f timestamp,irradiance --start 2022-12-01 --end 2023-01-01 -a Day --empty -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -80,7 +86,8 @@ pyr1,1,14.893976233333333
 pyr1,1,102.06783405555555
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 irradiance 2022-12-01 2023-01-01 -a Day --empty)
+  node ../src/ datums stream -s pyr1 -f irradiance --start 2022-12-01 --end 2023-01-01 -a Day --empty -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -90,7 +97,8 @@ EOF
 sourceId,objectId,voltage
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 voltage 2022-12-01 2023-01-01 -a Day)
+  node ../src/ datums stream -s pyr1 -f voltage --start 2022-12-01 --end 2023-01-01 -a Day -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -105,7 +113,8 @@ pyr1,1,14.893976233333333,
 pyr1,1,102.06783405555555,
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 irradiance,voltage 2022-12-01 2023-01-01 -a Day --partial)
+  node ../src/ datums stream -s pyr1 -f irradiance,voltage --start 2022-12-01 --end 2023-01-01 -a Day --partial -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -120,7 +129,8 @@ pyr1,1,
 pyr1,1,
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 voltage 2022-12-01 2023-01-01 -a Day --empty)
+  node ../src/ datums stream -s pyr1 -f voltage --start 2022-12-01 --end 2023-01-01 -a Day --empty -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }
 
@@ -152,6 +162,7 @@ pyr1,452,1669854013011,14.990587
 pyr1,452,1669854073012,14.988039
 EOF
 )
-  OUT=$(node ../src/ datums stream pyr1 timestamp,temperature 2022-12-01 2023-01-01)
+  node ../src/ datums stream -s pyr1 -f timestamp,temperature --start 2022-12-01 --end 2023-01-01 -o /tmp/out.txt
+  OUT=$(cat /tmp/out.txt)
   [ "$OUT" = "$EXPECTED" ]
 }


### PR DESCRIPTION
This PR makes sqc easier to use from the command line directly through, instead of having to run an interactive session of bash inside the container.

Positional arguments have been replaced, when appropriate, to using required flags.

I will create retag the current container on Dockerhub to 0.9, and when this PR is merged I will tag it as both 0.10 and latest. I will advise users to use ecogyenergy/solarquant:0.9 to retain the old behaviour, and to try the latest release to find any issues with their current workflow.